### PR TITLE
Bug 1371951 - Make browser-style checkboxes and radio buttons handle style themselves

### DIFF
--- a/extension.css
+++ b/extension.css
@@ -134,16 +134,18 @@ button.browser-style.default.focused {
   border-color: #fff;
 }
 
-/* Radio Buttons */
-.browser-style > input[type="radio"] {
-  display: none;
-}
-
-.browser-style > input[type="radio"] + label {
+.browser-style > label {
   -moz-user-select: none;
 }
 
-.browser-style > input[type="radio"] + label::before {
+.browser-style.disabled > label {
+  color: #999;
+  opacity: .5;
+}
+
+/* Radio Buttons */
+.browser-style > input[type="radio"] {
+  -moz-appearance: none;
   background-color: #fff;
   background-position: center;
   border: 1px solid #b1b1b1;
@@ -156,62 +158,48 @@ button.browser-style.default.focused {
   width: 16px;
 }
 
-.browser-style > input[type="radio"]:hover + label::before,
-.browser-style.hover > input[type="radio"]:not(active) + label::before {
+.browser-style > input[type="radio"]:hover,
+.browser-style.hover > input[type="radio"]:not(:active) {
   background-color: #fbfbfb;
   border-color: #b1b1b1;
 }
 
-.browser-style > input[type="radio"]:hover:active + label::before,
-.browser-style.pressed > input[type="radio"]:not(active) + label::before {
+.browser-style > input[type="radio"]:hover:active,
+.browser-style.pressed > input[type="radio"]:not(:active) {
   background-color: #ebebeb;
   border-color: #858585;
 }
 
-.browser-style > input[type="radio"]:checked + label::before {
+.browser-style > input[type="radio"]:checked {
   background-color: #0996f8;
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICA8Y2lyY2xlIGN4PSI4IiBjeT0iOCIgcj0iNCIgZmlsbD0iI2ZmZiIgLz4KPC9zdmc+Cg==);
   border-color: #0670cc;
 }
 
-.browser-style > input[type="radio"]:checked:hover + label::before,
-.browser-style.hover > input[type="radio"]:checked:not(active) + label::before {
+.browser-style > input[type="radio"]:checked:hover,
+.browser-style.hover > input[type="radio"]:checked:not(:active) {
   background-color: #0670cc;
   border-color: #005bab;
 }
 
-.browser-style > input[type="radio"]:checked:hover:active + label::before,
-.browser-style.pressed > input[type="radio"]:checked:not(active) + label::before {
+.browser-style > input[type="radio"]:checked:hover:active,
+.browser-style.pressed > input[type="radio"]:checked:not(:active) {
   background-color: #005bab;
   border-color: #004480;
 }
 
-.browser-style.disabled > input[type="radio"] + label,
-.browser-style.disabled > input[type="radio"]:hover + label,
-.browser-style.disabled > input[type="radio"]:hover:active + label {
-  color: #999;
-  opacity: .5;
-}
-
-.browser-style.focused > input[type="radio"] + label::before {
+.browser-style.focused > input[type="radio"] {
   border-color: #0996f8;
   box-shadow: 0 0 0 2px rgba(97, 181, 255, 0.75);
 }
 
-.browser-style.focused > input[type="radio"]:checked + label::before {
+.browser-style.focused > input[type="radio"]:checked {
   border-color: #fff;
 }
 
 /* Checkboxes */
 .browser-style > input[type="checkbox"] {
-  display: none;
-}
-
-.browser-style > input[type="checkbox"] + label {
-  -moz-user-select: none;
-}
-
-.browser-style > input[type="checkbox"] + label::before {
+  -moz-appearance: none;
   background-color: #fff;
   background-position: center;
   border: 1px solid #b1b1b1;
@@ -223,49 +211,42 @@ button.browser-style.default.focused {
   width: 16px;
 }
 
-.browser-style > input[type="checkbox"]:hover + label::before,
-.browser-style.hover > input[type="checkbox"]:not(active) + label::before {
+.browser-style > input[type="checkbox"]:hover,
+.browser-style.hover > input[type="checkbox"]:not(:active) {
   background-color: #fbfbfb;
   border-color: #b1b1b1;
 }
 
-.browser-style > input[type="checkbox"]:hover:active + label::before,
-.browser-style.pressed > input[type="checkbox"]:not(active) + label::before {
+.browser-style > input[type="checkbox"]:hover:active,
+.browser-style.pressed > input[type="checkbox"]:not(:active) {
   background-color: #ebebeb;
   border-color: #858585;
 }
 
-.browser-style > input[type="checkbox"]:checked + label::before {
+.browser-style > input[type="checkbox"]:checked {
   background-color: #0996f8;
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICA8cGF0aCBkPSJNNy43LDEyLjkgQzcuNCwxMy4zIDYuOCwxMy40IDYuNCwxMyBMMy4yLDkuOCBDMi44LDkuNCAyLjgsOC42IDMuMiw4LjIgQzMuNiw3LjggNC40LDcuOCA0LjgsOC4yIEw2LjksMTAuMyBMMTEuMSw0LjQgQzExLjUsMy45IDEyLjIsMy44IDEyLjcsNC4xIEMxMy4yLDQuNSAxMy4zLDUuMiAxMyw1LjcgTDcuNywxMi45IEw3LjcsMTIuOSBaIiBmaWxsPSIjZmZmIiAvPgo8L3N2Zz4K);
   border-color: #0670cc;
 }
 
-.browser-style > input[type="checkbox"]:checked:hover + label::before,
-.browser-style.hover > input[type="checkbox"]:checked:not(active) + label::before {
+.browser-style > input[type="checkbox"]:checked:hover,
+.browser-style.hover > input[type="checkbox"]:checked:not(:active) {
   background-color: #0670cc;
   border-color: #005bab;
 }
 
-.browser-style > input[type="checkbox"]:checked:hover:active + label::before,
-.browser-style.pressed > input[type="checkbox"]:checked:not(active) + label::before {
+.browser-style > input[type="checkbox"]:checked:hover:active,
+.browser-style.pressed > input[type="checkbox"]:checked:not(:active) {
   background-color: #005bab;
   border-color: #004480;
 }
 
-.browser-style.disabled > input[type="checkbox"] + label,
-.browser-style.disabled > input[type="checkbox"]:hover + label,
-.browser-style.disabled > input[type="checkbox"]:hover:active + label {
-  color: #999;
-  opacity: .5;
-}
-
-.browser-style.focused > input[type="checkbox"] + label::before {
+.browser-style.focused > input[type="checkbox"] {
   border-color: #0996f8;
   box-shadow: 0 0 0 2px rgba(97, 181, 255, 0.75);
 }
 
-.browser-style.focused > input[type="checkbox"]:checked + label::before {
+.browser-style.focused > input[type="checkbox"]:checked {
   border-color: #fff;
 }
 
@@ -545,12 +526,12 @@ textarea.browser-style:focus:hover {
   background-color: rgba(0, 0, 0, 0.1);
 }
 
-.panel-section-tabs-button.select.browser-styleed {
+.panel-section-tabs-button.selected {
   box-shadow: 0 -1px 0 #0670cc inset, 0 -4px 0 #0996f8 inset;
   color: #0996f8;
 }
 
-.panel-section-tabs-button.select.browser-styleed:hover {
+.panel-section-tabs-button.selected:hover {
   color: #0670cc;
 }
 


### PR DESCRIPTION
This removes the requirement for browser-style checkboxes and radio buttons to be followed by a label since the reason why this was originally done no longer applies because [bug 418833](https://bugzil.la/418833) made it possible for checkboxes and radio buttons to handle styling themselves rather than requiring a `label::before` element.

---

## See also:
- [~~bug 418833~~](https://bugzil.la/418833 "418833 - can't define the style of input when the type is set to &quot;checkbox&quot; or &quot;radio&quot; with CSS")
- [bug 1371951](https://bugzil.la/1371951 "1371951 - browser_style Checkbox is invisible when not in front of its associated label element")